### PR TITLE
let IHierarchy impls be maps

### DIFF
--- a/src/dispatch_map/hierarchy.clj
+++ b/src/dispatch_map/hierarchy.clj
@@ -8,6 +8,6 @@
   "Returns true if (= child parent), or child is directly or
   indirectly derived from parent in hierarchy."
   [hierarchy child parent]
-  (if (map? hierarchy)
-    (clojure.core/isa? hierarchy child parent)
-    (-isa hierarchy child parent)))
+  (if (satisfies? IHierarchy hierarchy)
+    (-isa hierarchy child parent)
+    (clojure.core/isa? hierarchy child parent)))


### PR DESCRIPTION
This just flips the check, assuming things that aren't IHierarchy are core hierarchy maps. I found it convenient to defrecord an IHierarchy with parents/descendants/ancestors for core hierarchy compatibility.
